### PR TITLE
feat: show and manage captains info on game board

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,28 +1,29 @@
 <script setup>
-import { computed, toRefs, inject } from "vue";
-
-import { usePlayersStore } from "@/stores/players.js";
+import { computed, toRefs } from "vue";
 
 const props = defineProps({
     card: {
         type: Object,
         required: true,
     },
+    isCaptainView: {
+        type: Boolean,
+    },
+    open: {
+        type: Function,
+    },
 });
 
 const { card } = toRefs(props);
 
-const broker = inject("broker");
-const { isCaptainView } = usePlayersStore();
-
-const open = (idx) => {
+const open = () => {
     if (card.value.closed()) {
-        broker.open(idx);
+        props.open(card.value.idx);
     }
 };
 
 const cardClass = computed(() => {
-    if (!isCaptainView() && card.value.closed()) {
+    if (!props.isCaptainView && card.value.closed()) {
         return "card-3 shadow-md hover:shadow-xl";
     }
     return `card-${card.value.state} ${card.value.closed() ? "shadow-md hover:shadow-xl" : "shadow-xl"}`;
@@ -31,9 +32,13 @@ const cardClass = computed(() => {
 
 <template>
     <article
-        class="animate__animated transition-transform duration-150 cursor-pointer flex items-center justify-center text-4xl border border-zinc-400 rounded-md shadow-zinc-500/50"
-        :class="[cardClass, { animate__flipInY: !card.closed() }]"
-        @click="open(card.idx)"
+        class="animate__animated transition-transform duration-150 flex items-center justify-center text-4xl border border-zinc-400 rounded-md shadow-zinc-500/50"
+        :class="[
+            cardClass,
+            { animate__flipInY: !card.closed() },
+            { 'cursor-pointer': card.closed() },
+        ]"
+        @click="open()"
     >
         <span class="xl:text-4xl lg:text-2xl md:text-lg">{{ card.word }}</span>
     </article>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -1,18 +1,28 @@
 <script setup>
-import { computed, inject } from "vue";
+import { inject } from "vue";
 import { storeToRefs } from "pinia";
 
+import Toggle from "@/components/Toggle.vue";
 import { useGameStore } from "@/stores/game.js";
 import { usePlayersStore } from "@/stores/players.js";
 
 const broker = inject("broker");
-const { score, gameOver } = storeToRefs(useGameStore());
+const { score } = storeToRefs(useGameStore());
 const { isCaptainView } = usePlayersStore();
+const toggleCaptain = () => {
+    broker.toggleCaptain(!isCaptainView());
+};
 </script>
 
 <template>
     <div class="grid grid-cols-5 gap-4 text-4xl">
-        <div class="flex justify-center"></div>
+        <div class="flex justify-center">
+            <Toggle
+                team="red"
+                :isCaptainView="isCaptainView()"
+                :toggleCaptain="toggleCaptain"
+            />
+        </div>
         <div class="flex justify-center text-code-red-700">
             {{ score.red }}
         </div>
@@ -28,30 +38,11 @@ const { isCaptainView } = usePlayersStore();
             {{ score.blue }}
         </div>
         <div class="flex justify-center">
-            <label
-                class="inline-flex items-center cursor-pointer"
-                for="captain"
-            >
-                <svg
-                    viewBox="0 0 512 512"
-                    class="w-8 h-8 mr-2 fill-teal-700"
-                    xmlns="http://www.w3.org/2000/svg"
-                >
-                    <path
-                        d="M256 38.55c-30.5 0-55 24.52-55 55c0 30.45 24.5 54.95 55 54.95s55-24.5 55-54.95c0-30.48-24.5-55-55-55M191.3 164.4c-5.7 0-11.1.4-16 1.4c-19.9 4-34.1 15.6-43.1 35.4c-9.4 20.6-12.1 50.6-5.8 88l6 5.9c13.8 13.8 36.1 21.4 58.6 21.4c21.1 0 42.1-6.7 56-19V179.2c-21-9.8-39.8-14.5-55.7-14.8m129.4 0c-15.9.3-34.7 5-55.7 14.8v118.3c13.9 12.3 34.9 19 56 19c22.5 0 44.8-7.6 58.6-21.4l6-5.9c6.3-37.4 3.6-67.4-5.8-88c-9-19.8-23.2-31.4-43.1-35.4c-4.9-1-10.3-1.4-16-1.4m-209.1 14.4h-.2c-30 .7-55.2 12.1-70.2 32.1c-13.3 17.8-19.5 42.9-13.6 76c.9 5.1 2.1 10.5 3.7 16c24.5 18.5 54.3 18.6 78.9.3c-9.2-44.8-6.9-81.9 5.6-109.4q3.6-7.95 8.4-14.7c-2.9-.2-5.8-.3-8.6-.3h-3.9c-.1 0-.1-.1-.1 0m288.8 0c0-.1 0 0-.1 0h-3.9c-2.8 0-5.7.1-8.6.3q4.8 6.75 8.4 14.7c12.5 27.5 14.8 64.6 5.6 109.4c24.5 18.3 54.4 18.2 78.9-.3c1.5-5.5 2.8-10.9 3.7-16c5.9-33.1-.3-58.2-13.6-76c-15-20-40.2-31.4-70.2-32.1zM132.8 318.4c6.9 26.1 17.7 54.9 32.9 86.1h58.6l22.7-56.7v-28c-16.4 10-36.3 14.7-56 14.7c-20.7 0-41.5-5.2-58.2-16.1m246.4 0c-16.7 10.9-37.5 16.1-58.2 16.1c-19.7 0-39.6-4.7-56-14.7v28l22.7 56.7h58.6c15.2-31.2 26-60 32.9-86.1m-264.6 3.4c-23 13.9-50.1 16.1-74.5 6.4c9.6 23 24.1 48.5 44.5 76.3h61c-14-29.6-24.2-57.2-31-82.7m282.8 0c-6.8 25.5-17 53.1-31 82.7h61c20.4-27.8 34.9-53.3 44.5-76.3c-24.3 9.7-51.5 7.5-74.5-6.4M256 373.7l-22.1 55.4l22.1 44.3l22.1-44.3zM91.53 422.5l11.47 46h35.3l-23-23l23-23zm90.27 0l16.6 16.6l6.3 6.4l-23 23h51.7l-19.3-38.6l3-7.4zm113.1 0l1.5 3.7l1.5 3.7l-19.3 38.6h51.7l-23-23l23-23zm78.9 0l16.6 16.6l6.3 6.4l-23 23H409l11.5-46zM160 426.2l-19.3 19.3l19.3 19.3l19.3-19.3zm192 0l-19.3 19.3l19.3 19.3l19.3-19.3z"
-                    />
-                </svg>
-                <input
-                    type="checkbox"
-                    id="captain"
-                    :checked="isCaptainView()"
-                    @change="broker.toggleCaptain(!isCaptainView())"
-                    class="sr-only peer"
-                />
-                <div
-                    class="relative w-14 h-7 bg-gray-200 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all dark:border-gray-600 peer-checked:bg-teal-700"
-                ></div>
-            </label>
+            <Toggle
+                team="blue"
+                :isCaptainView="isCaptainView()"
+                :toggleCaptain="toggleCaptain"
+            />
         </div>
     </div>
 </template>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -12,18 +12,7 @@ const { isCaptainView } = usePlayersStore();
 
 <template>
     <div class="grid grid-cols-5 gap-4 text-4xl">
-        <div class="flex justify-center">
-            <div
-                :class="{
-                    'text-black': score.red != 0 && score.blue != 0,
-                    'text-code-red-700': score.red == 0,
-                    'text-code-blue-700': score.blue == 0,
-                }"
-                v-show="gameOver != ''"
-            >
-                {{ gameOver }}
-            </div>
-        </div>
+        <div class="flex justify-center"></div>
         <div class="flex justify-center text-code-red-700">
             {{ score.red }}
         </div>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -8,9 +8,15 @@ import { usePlayersStore } from "@/stores/players.js";
 
 const broker = inject("broker");
 const { score } = storeToRefs(useGameStore());
-const { isCaptainView } = usePlayersStore();
-const toggleCaptain = () => {
-    broker.toggleCaptain(!isCaptainView());
+const { isRedCaptain, isRedCaptainTaken, isBlueCaptain, isBlueCaptainTaken } =
+    usePlayersStore();
+
+const toggleRedCaptain = () => {
+    broker.setCaptain(isRedCaptain() ? 0 : 1);
+};
+
+const toggleBlueCaptain = () => {
+    broker.setCaptain(isBlueCaptain() ? 0 : 2);
 };
 </script>
 
@@ -19,8 +25,9 @@ const toggleCaptain = () => {
         <div class="flex justify-center">
             <Toggle
                 team="red"
-                :isCaptainView="isCaptainView()"
-                :toggleCaptain="toggleCaptain"
+                :disabled="isRedCaptainTaken() && !isRedCaptain()"
+                :isCaptainView="isRedCaptain()"
+                :toggleCaptain="toggleRedCaptain"
             />
         </div>
         <div class="flex justify-center text-code-red-700">
@@ -40,8 +47,9 @@ const toggleCaptain = () => {
         <div class="flex justify-center">
             <Toggle
                 team="blue"
-                :isCaptainView="isCaptainView()"
-                :toggleCaptain="toggleCaptain"
+                :disabled="isBlueCaptainTaken() && !isBlueCaptain()"
+                :isCaptainView="isBlueCaptain()"
+                :toggleCaptain="toggleBlueCaptain"
             />
         </div>
     </div>

--- a/src/components/Info.vue
+++ b/src/components/Info.vue
@@ -43,15 +43,22 @@ const { players } = storeToRefs(playersStore);
             <div class="flex justify-end -space-x-1.5">
                 <div class="relative" v-for="player in players">
                     <img
-                        class="inline-block w-16 h-16 p-1 rounded-full ring-2 ring-gray-300 shadow-md bg-white"
-                        :class="{ 'ring-code-blue-700': player.captain }"
+                        class="inline-block w-16 h-16 p-1 rounded-full ring-2 shadow-md bg-white"
+                        :class="{
+                            'ring-gray-300': player.captain == 0,
+                            'ring-code-red-700': player.captain == 1,
+                            'ring-code-blue-700': player.captain == 2,
+                        }"
                         :src="player.avatar"
                         :alt="player.name"
                     />
                     <span
-                        v-show="player.captain"
+                        v-show="player.captain != 0"
                         class="absolute top-0 left-12 w-3.5 h-3.5 border-2 border-white rounded-full"
-                        :class="{ 'bg-code-blue-700 ': player.captain }"
+                        :class="{
+                            'bg-code-red-700': player.captain == 1,
+                            'bg-code-blue-700': player.captain == 2,
+                        }"
                     ></span>
                 </div>
             </div>

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -1,16 +1,29 @@
 <script setup>
+import { inject } from "vue";
 import { storeToRefs } from "pinia";
 
+const broker = inject("broker");
 import { useGameStore } from "@/stores/game.js";
+import { usePlayersStore } from "@/stores/players.js";
 import Card from "@/components/Card.vue";
 
 const { board, score, gameOver } = storeToRefs(useGameStore());
+const { isCaptainView } = usePlayersStore();
+const open = (idx) => {
+    broker.open(idx);
+};
 </script>
 
 <template>
     <div class="relative h-[70vh]">
         <div class="h-full w-full grid grid-cols-5 gap-12">
-            <Card v-for="(card, i) in board" :key="i" :card="card" />
+            <Card
+                v-for="(card, i) in board"
+                :key="i"
+                :card="card"
+                :isCaptainView="isCaptainView()"
+                :open="open"
+            />
         </div>
         <div
             class="absolute top-0 left-0 w-full h-0 flex flex-col justify-center items-center bg-zinc-100 bg-opacity-90 backdrop-blur-sm"

--- a/src/components/Screen.vue
+++ b/src/components/Screen.vue
@@ -4,12 +4,28 @@ import { storeToRefs } from "pinia";
 import { useGameStore } from "@/stores/game.js";
 import Card from "@/components/Card.vue";
 
-const store = useGameStore();
-const { board } = storeToRefs(store);
+const { board, score, gameOver } = storeToRefs(useGameStore());
 </script>
 
 <template>
-    <div class="grid grid-cols-5 gap-12 h-[70vh]">
-        <Card v-for="(card, i) in board" :key="i" :card="card" />
+    <div class="relative h-[70vh]">
+        <div class="h-full w-full grid grid-cols-5 gap-12">
+            <Card v-for="(card, i) in board" :key="i" :card="card" />
+        </div>
+        <div
+            class="absolute top-0 left-0 w-full h-0 flex flex-col justify-center items-center bg-zinc-100 bg-opacity-90 backdrop-blur-sm"
+            :class="{ 'h-full duration-500': gameOver != '' }"
+        >
+            <h1
+                class="text-6xl"
+                :class="{
+                    'text-black': score.red != 0 && score.blue != 0,
+                    'text-code-red-700': score.red == 0,
+                    'text-code-blue-700': score.blue == 0,
+                }"
+            >
+                {{ gameOver }}
+            </h1>
+        </div>
     </div>
 </template>

--- a/src/components/Toggle.vue
+++ b/src/components/Toggle.vue
@@ -1,0 +1,42 @@
+<script setup>
+const props = defineProps({
+    team: {
+        type: String,
+        required: true,
+    },
+    isCaptainView: {
+        type: Boolean,
+    },
+    toggleCaptain: {
+        type: Function,
+    },
+});
+</script>
+
+<template>
+    <label class="inline-flex items-center cursor-pointer" :for="props.team">
+        <svg
+            viewBox="0 0 512 512"
+            class="w-8 h-8 mr-2"
+            :class="{
+                'fill-code-red-700': props.team == 'red',
+                'fill-code-blue-700': props.team == 'blue',
+            }"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                d="M256 38.55c-30.5 0-55 24.52-55 55c0 30.45 24.5 54.95 55 54.95s55-24.5 55-54.95c0-30.48-24.5-55-55-55M191.3 164.4c-5.7 0-11.1.4-16 1.4c-19.9 4-34.1 15.6-43.1 35.4c-9.4 20.6-12.1 50.6-5.8 88l6 5.9c13.8 13.8 36.1 21.4 58.6 21.4c21.1 0 42.1-6.7 56-19V179.2c-21-9.8-39.8-14.5-55.7-14.8m129.4 0c-15.9.3-34.7 5-55.7 14.8v118.3c13.9 12.3 34.9 19 56 19c22.5 0 44.8-7.6 58.6-21.4l6-5.9c6.3-37.4 3.6-67.4-5.8-88c-9-19.8-23.2-31.4-43.1-35.4c-4.9-1-10.3-1.4-16-1.4m-209.1 14.4h-.2c-30 .7-55.2 12.1-70.2 32.1c-13.3 17.8-19.5 42.9-13.6 76c.9 5.1 2.1 10.5 3.7 16c24.5 18.5 54.3 18.6 78.9.3c-9.2-44.8-6.9-81.9 5.6-109.4q3.6-7.95 8.4-14.7c-2.9-.2-5.8-.3-8.6-.3h-3.9c-.1 0-.1-.1-.1 0m288.8 0c0-.1 0 0-.1 0h-3.9c-2.8 0-5.7.1-8.6.3q4.8 6.75 8.4 14.7c12.5 27.5 14.8 64.6 5.6 109.4c24.5 18.3 54.4 18.2 78.9-.3c1.5-5.5 2.8-10.9 3.7-16c5.9-33.1-.3-58.2-13.6-76c-15-20-40.2-31.4-70.2-32.1zM132.8 318.4c6.9 26.1 17.7 54.9 32.9 86.1h58.6l22.7-56.7v-28c-16.4 10-36.3 14.7-56 14.7c-20.7 0-41.5-5.2-58.2-16.1m246.4 0c-16.7 10.9-37.5 16.1-58.2 16.1c-19.7 0-39.6-4.7-56-14.7v28l22.7 56.7h58.6c15.2-31.2 26-60 32.9-86.1m-264.6 3.4c-23 13.9-50.1 16.1-74.5 6.4c9.6 23 24.1 48.5 44.5 76.3h61c-14-29.6-24.2-57.2-31-82.7m282.8 0c-6.8 25.5-17 53.1-31 82.7h61c20.4-27.8 34.9-53.3 44.5-76.3c-24.3 9.7-51.5 7.5-74.5-6.4M256 373.7l-22.1 55.4l22.1 44.3l22.1-44.3zM91.53 422.5l11.47 46h35.3l-23-23l23-23zm90.27 0l16.6 16.6l6.3 6.4l-23 23h51.7l-19.3-38.6l3-7.4zm113.1 0l1.5 3.7l1.5 3.7l-19.3 38.6h51.7l-23-23l23-23zm78.9 0l16.6 16.6l6.3 6.4l-23 23H409l11.5-46zM160 426.2l-19.3 19.3l19.3 19.3l19.3-19.3zm192 0l-19.3 19.3l19.3 19.3l19.3-19.3z"
+            />
+        </svg>
+        <input
+            type="checkbox"
+            :id="props.team"
+            :checked="props.isCaptainView"
+            @change="props.toggleCaptain()"
+            class="sr-only peer"
+        />
+        <div
+            class="relative w-14 h-7 bg-gray-200 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all dark:border-gray-600 peer-checked:bg-teal-700"
+        ></div>
+    </label>
+</template>

--- a/src/components/Toggle.vue
+++ b/src/components/Toggle.vue
@@ -10,6 +10,9 @@ const props = defineProps({
     toggleCaptain: {
         type: Function,
     },
+    disabled: {
+        type: Boolean,
+    },
 });
 </script>
 
@@ -32,11 +35,20 @@ const props = defineProps({
             type="checkbox"
             :id="props.team"
             :checked="props.isCaptainView"
+            :disabled="props.disabled"
             @change="props.toggleCaptain()"
             class="sr-only peer"
         />
         <div
-            class="relative w-14 h-7 bg-gray-200 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all dark:border-gray-600 peer-checked:bg-teal-700"
+            :class="{
+                'peer-checked:bg-code-red-700': props.team == 'red',
+                'peer-checked:bg-code-blue-700': props.team == 'blue',
+                'bg-zinc-200': props.disabled,
+                'after:border-zinc-200': props.disabled,
+                'bg-zinc-400': !props.disabled,
+                'after:border-zinc-400': !props.disabled,
+            }"
+            class="relative w-14 h-7 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border after:rounded-full after:h-6 after:w-6 after:transition-all"
         ></div>
     </label>
 </template>

--- a/src/plugins/broker.js
+++ b/src/plugins/broker.js
@@ -146,6 +146,7 @@ class Broker {
 
   open(idx) {
     console.debug(`broker: publish open ${idx}`);
+    this.gameStore.open(idx);
     this.channel.publish("open", idx);
   }
 
@@ -156,6 +157,8 @@ class Broker {
 
   toggleCaptain(isCaptain) {
     console.debug(`broker: send toggleCaptain ${isCaptain}`);
+    this.playersStore.setCaptain(this.#username, isCaptain);
+    this.gameStore.isCaptainView = isCaptain;
     this.channel.presence.update({ isCaptain });
   }
 

--- a/src/plugins/broker.js
+++ b/src/plugins/broker.js
@@ -56,7 +56,7 @@ class Broker {
       "enter",
       async ({ clientId: player }) => {
         console.debug(`broker: presence enter ${player}`);
-        this.playersStore.addPlayer(player, { isCaptain: false });
+        this.playersStore.addPlayer(player, { captain: 0 });
       },
     );
 
@@ -72,12 +72,9 @@ class Broker {
       console.debug(`broker: presence update ${JSON.stringify(msg)}`);
       const {
         clientId: player,
-        data: { isCaptain },
+        data: { captain },
       } = msg;
-      this.playersStore.setCaptain(player, isCaptain);
-      if (player == this.#username) {
-        this.gameStore.isCaptainView = isCaptain;
-      }
+      this.playersStore.setCaptain(player, captain);
     });
 
     this.#syncLeader = this.#username;
@@ -155,11 +152,10 @@ class Broker {
     this.channel.publish("nextGame", null);
   }
 
-  toggleCaptain(isCaptain) {
-    console.debug(`broker: send toggleCaptain ${isCaptain}`);
-    this.playersStore.setCaptain(this.#username, isCaptain);
-    this.gameStore.isCaptainView = isCaptain;
-    this.channel.presence.update({ isCaptain });
+  setCaptain(captain) {
+    console.debug(`broker: send setCaptain ${captain}`);
+    this.playersStore.setCaptain(this.#username, captain);
+    this.channel.presence.update({ captain });
   }
 
   async disconnect() {

--- a/src/stores/players.js
+++ b/src/stores/players.js
@@ -33,14 +33,19 @@ export const usePlayersStore = defineStore("players", () => {
     },
   });
 
+  const Captain = Object.freeze({
+    None: 0,
+    Red: 1,
+    Blue: 2,
+  });
+
   const addPlayer = (p, data) => {
     players.value[p] = {
       name: p,
       avatar: regulars[p]
         ? regulars[p].avatar
         : "http://placekitten.com/250/250",
-      captain: data ? data.isCaptain : false,
-      team: "white",
+      captain: Captain.None,
     };
   };
 
@@ -52,13 +57,37 @@ export const usePlayersStore = defineStore("players", () => {
     player.value = p;
   };
 
-  const setCaptain = (p, isCaptain) => {
-    players.value[p].captain = isCaptain;
+  const setCaptain = (p, captain) => {
+    if (
+      captain == Captain.None ||
+      captain == Captain.Red ||
+      captain == Captain.Blue
+    ) {
+      players.value[p].captain = captain;
+    }
+  };
+
+  const isRedCaptain = () => {
+    const me = players.value[player.value];
+    return me ? me.captain == Captain.Red : false;
+  };
+
+  const isRedCaptainTaken = () => {
+    return Object.values(players.value).some((p) => p.captain == Captain.Red);
+  };
+
+  const isBlueCaptain = () => {
+    const me = players.value[player.value];
+    return me ? me.captain == Captain.Blue : false;
+  };
+
+  const isBlueCaptainTaken = () => {
+    return Object.values(players.value).some((p) => p.captain == Captain.Blue);
   };
 
   const isCaptainView = () => {
     const me = players.value[player.value];
-    return me ? me.captain : false;
+    return me ? me.captain != Captain.None : false;
   };
 
   const newGame = () => {
@@ -79,6 +108,10 @@ export const usePlayersStore = defineStore("players", () => {
     removePlayer,
     setPlayer,
     setCaptain,
+    isRedCaptain,
+    isRedCaptainTaken,
+    isBlueCaptain,
+    isBlueCaptainTaken,
     isCaptainView,
     newGame,
     $reset,

--- a/src/stores/players.js
+++ b/src/stores/players.js
@@ -6,20 +6,15 @@ export const usePlayersStore = defineStore("players", () => {
   const players = ref({});
 
   const regulars = reactive({
-    Eiri: {
-      name: "Eiri",
-      lj: "eiri",
-      avatar: "https://l-userpic.livejournal.com/38941189/689880", // https://l-userpic.livejournal.com/127274177/689880
-    },
     Akari: {
       name: "Akari",
       lj: "akari_chan",
       avatar: "https://l-userpic.livejournal.com/120407741/755293",
     },
-    Vitaliy: {
-      name: "Vitaliy",
-      lj: "seminarist",
-      avatar: "https://l-userpic.livejournal.com/45172718/788486",
+    Eiri: {
+      name: "Eiri",
+      lj: "eiri",
+      avatar: "https://l-userpic.livejournal.com/38941189/689880", // https://l-userpic.livejournal.com/127274177/689880
     },
     Ikadell: {
       name: "Ikadell",
@@ -30,6 +25,11 @@ export const usePlayersStore = defineStore("players", () => {
       name: "Friday",
       lj: "next_friday",
       avatar: "https://l-userpic.livejournal.com/57379634/818233",
+    },
+    Vitaliy: {
+      name: "Vitaliy",
+      lj: "seminarist",
+      avatar: "https://l-userpic.livejournal.com/45172718/788486",
     },
   });
 


### PR DESCRIPTION
Communicate when player set themselves as captain. Mark their icon. Allow only one player per color.

Closes #6 