### PR TITLE
fix: scores and gameOver as computed values

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -7,7 +7,7 @@ import { useGameStore } from "@/stores/game.js";
 import { usePlayersStore } from "@/stores/players.js";
 
 const broker = inject("broker");
-const { score } = storeToRefs(useGameStore());
+const { redScore, blueScore } = storeToRefs(useGameStore());
 const { isRedCaptain, isRedCaptainTaken, isBlueCaptain, isBlueCaptainTaken } =
     usePlayersStore();
 
@@ -31,7 +31,7 @@ const toggleBlueCaptain = () => {
             />
         </div>
         <div class="flex justify-center text-code-red-700">
-            {{ score.red }}
+            {{ redScore }}
         </div>
         <div class="flex justify-center">
             <button
@@ -42,7 +42,7 @@ const toggleBlueCaptain = () => {
             </button>
         </div>
         <div class="flex justify-center text-code-blue-700">
-            {{ score.blue }}
+            {{ blueScore }}
         </div>
         <div class="flex justify-center">
             <Toggle

--- a/src/components/Info.vue
+++ b/src/components/Info.vue
@@ -8,7 +8,7 @@ import { usePlayersStore } from "@/stores/players";
 
 const room = ref(localStorage.getItem("room"));
 const store = useGameStore();
-const { turn, score, gameOver } = storeToRefs(store);
+const { turn, redScore, blueScore, gameOver } = storeToRefs(store);
 
 const playersStore = usePlayersStore();
 const { players } = storeToRefs(playersStore);
@@ -64,9 +64,9 @@ const { players } = storeToRefs(playersStore);
         </div>
         <div
             :class="{
-                'text-black': score.red != 0 && score.blue != 0,
-                'text-code-red-700': score.red == 0,
-                'text-code-blue-700': score.blue == 0,
+                'text-black': redScore != 0 && blueScore != 0,
+                'text-code-red-700': redScore == 0,
+                'text-code-blue-700': blueScore == 0,
             }"
         >
             {{ gameOver }}


### PR DESCRIPTION
State of scores was drifting for reloaded sessions, so this converts scores and gameOver to be computed values to deal with it.